### PR TITLE
 October publication for the repository name change

### DIFF
--- a/NOTE/2024-10/index.html
+++ b/NOTE/2024-10/index.html
@@ -1,0 +1,858 @@
+<!DOCTYPE html><html lang="en" dir="ltr" data-lt-installed="true"><head>
+<meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+<meta name="generator" content="ReSpec 35.1.2">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<style>
+span.example-title{text-transform:none}
+:is(aside,div).example,div.illegal-example{padding:.5em;margin:1em 0;position:relative;clear:both}
+div.illegal-example{color:red}
+div.illegal-example p{color:#000}
+aside.example div.example{border-left-width:.1em;border-color:#999;background:#fff}
+</style>
+<style>
+.issue-label{text-transform:initial}
+.warning>p:first-child{margin-top:0}
+.warning{padding:.5em;border-left-width:.5em;border-left-style:solid}
+span.warning{padding:.1em .5em .15em}
+.issue.closed span.issue-number{text-decoration:line-through}
+.issue.closed span.issue-number::after{content:" (Closed)";font-size:smaller}
+.warning{border-color:#f11;border-color:var(--warning-border,#f11);border-width:.2em;border-style:solid;background:#fbe9e9;background:var(--warning-bg,#fbe9e9);color:#000;color:var(--text,#000)}
+.warning-title:before{content:"⚠";font-size:1.3em;float:left;padding-right:.3em;margin-top:-.3em}
+li.task-list-item{list-style:none}
+input.task-list-item-checkbox{margin:0 .35em .25em -1.6em;vertical-align:middle}
+.issue a.respec-gh-label{padding:5px;margin:0 2px 0 2px;font-size:10px;text-transform:none;text-decoration:none;font-weight:700;border-radius:4px;position:relative;bottom:2px;border:none;display:inline-block}
+</style>
+<style>
+dfn{cursor:pointer}
+.dfn-panel{position:absolute;z-index:35;min-width:300px;max-width:500px;padding:.5em .75em;margin-top:.6em;font-family:"Helvetica Neue",sans-serif;font-size:small;background:#fff;background:var(--indextable-hover-bg,#fff);color:#000;color:var(--text,#000);box-shadow:0 1em 3em -.4em rgba(0,0,0,.3),0 0 1px 1px rgba(0,0,0,.05);box-shadow:0 1em 3em -.4em var(--tocsidebar-shadow,rgba(0,0,0,.3)),0 0 1px 1px var(--tocsidebar-shadow,rgba(0,0,0,.05));border-radius:2px}
+.dfn-panel:not(.docked)>.caret{position:absolute;top:-9px}
+.dfn-panel:not(.docked)>.caret::after,.dfn-panel:not(.docked)>.caret::before{content:"";position:absolute;border:10px solid transparent;border-top:0;border-bottom:10px solid #fff;border-bottom-color:var(--indextable-hover-bg,#fff);top:0}
+.dfn-panel:not(.docked)>.caret::before{border-bottom:9px solid #a2a9b1;border-bottom-color:var(--indextable-hover-bg,#a2a9b1)}
+.dfn-panel *{margin:0}
+.dfn-panel b{display:block;color:#000;color:var(--text,#000);margin-top:.25em}
+.dfn-panel ul a[href]{color:#333;color:var(--text,#333)}
+.dfn-panel>div{display:flex}
+.dfn-panel a.self-link{font-weight:700;margin-right:auto}
+.dfn-panel .marker{padding:.1em;margin-left:.5em;border-radius:.2em;text-align:center;white-space:nowrap;font-size:90%;color:#040b1c}
+.dfn-panel .marker.dfn-exported{background:#d1edfd;box-shadow:0 0 0 .125em #1ca5f940}
+.dfn-panel .marker.idl-block{background:#8ccbf2;box-shadow:0 0 0 .125em #0670b161}
+.dfn-panel a:not(:hover){text-decoration:none!important;border-bottom:none!important}
+.dfn-panel a[href]:hover{border-bottom-width:1px}
+.dfn-panel ul{padding:0}
+.dfn-panel li{margin-left:1em}
+.dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
+</style>
+  
+<title>Verifiable Credential Extensions</title>
+  
+
+  
+<style id="respec-mainstyle">
+@keyframes pop{
+0%{transform:scale(1,1)}
+25%{transform:scale(1.25,1.25);opacity:.75}
+100%{transform:scale(1,1)}
+}
+a.internalDFN{color:inherit;border-bottom:1px solid #99c;text-decoration:none}
+a.externalDFN{color:inherit;border-bottom:1px dotted #ccc;text-decoration:none}
+a.bibref{text-decoration:none}
+.respec-offending-element:target{animation:pop .25s ease-in-out 0s 1}
+.respec-offending-element,a[href].respec-offending-element{text-decoration:red wavy underline}
+@supports not (text-decoration:red wavy underline){
+.respec-offending-element:not(pre){display:inline-block}
+.respec-offending-element{background:url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=) bottom repeat-x}
+}
+#references :target{background:#eaf3ff;animation:pop .4s ease-in-out 0s 1}
+cite .bibref{font-style:normal}
+a[href].orcid{padding-left:4px;padding-right:4px}
+a[href].orcid>svg{margin-bottom:-2px}
+ol.tof,ul.tof{list-style:none outside none}
+.caption{margin-top:.5em;font-style:italic}
+#issue-summary>ul{column-count:2}
+#issue-summary li{list-style:none;display:inline-block}
+details.respec-tests-details{margin-left:1em;display:inline-block;vertical-align:top}
+details.respec-tests-details>*{padding-right:2em}
+details.respec-tests-details[open]{z-index:999999;position:absolute;border:thin solid #cad3e2;border-radius:.3em;background-color:#fff;padding-bottom:.5em}
+details.respec-tests-details[open]>summary{border-bottom:thin solid #cad3e2;padding-left:1em;margin-bottom:1em;line-height:2em}
+details.respec-tests-details>ul{width:100%;margin-top:-.3em}
+details.respec-tests-details>li{padding-left:1em}
+.self-link:hover{opacity:1;text-decoration:none;background-color:transparent}
+aside.example .marker>a.self-link{color:inherit}
+.header-wrapper{display:flex;align-items:baseline}
+:is(h2,h3,h4,h5,h6):not(#toc>h2,#abstract>h2,#sotd>h2,.head>h2){position:relative;left:-.5em}
+:is(h2,h3,h4,h5,h6):not(#toch2)+a.self-link{color:inherit;order:-1;position:relative;left:-1.1em;font-size:1rem;opacity:.5}
+:is(h2,h3,h4,h5,h6)+a.self-link::before{content:"§";text-decoration:none;color:var(--heading-text)}
+:is(h2,h3)+a.self-link{top:-.2em}
+:is(h4,h5,h6)+a.self-link::before{color:#000}
+@media (max-width:767px){
+dd{margin-left:0}
+}
+@media print{
+.removeOnSave{display:none}
+}
+</style>
+  
+  
+  
+<style>
+
+    .label-legend dd{
+      margin-top: 8px;
+    }
+  .label-deprecated {
+    font-weight: bold;
+    background: #ef9a9a;
+    border-radius: 8px;
+    padding: 4px;
+  }
+  .label-no-contact-info {
+    font-weight: bold;
+    background: #ffe082;
+    border-radius: 8px;
+    padding: 4px;
+  }
+  pre .highlight {
+    font-weight: bold;
+    color: green;
+  }
+  pre .comment {
+    color: SteelBlue;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+  }
+  
+</style>
+
+<meta name="color-scheme" content="light">
+<meta name="description" content="This document serves as an unofficial list of all known Verifiable Credential
+specifications whether they are released by a global standards setting
+organization, a community group, an open source project, or an individual.">
+<link rel="canonical" href="https://www.w3.org/TR/vc-extensions/">
+<style>
+.hljs{--base:#fafafa;--mono-1:#383a42;--mono-2:#686b77;--mono-3:#717277;--hue-1:#0b76c5;--hue-2:#336ae3;--hue-3:#a626a4;--hue-4:#42803c;--hue-5:#ca4706;--hue-5-2:#c91243;--hue-6:#986801;--hue-6-2:#9a6a01}
+@media (prefers-color-scheme:dark){
+.hljs{--base:#282c34;--mono-1:#abb2bf;--mono-2:#818896;--mono-3:#5c6370;--hue-1:#56b6c2;--hue-2:#61aeee;--hue-3:#c678dd;--hue-4:#98c379;--hue-5:#e06c75;--hue-5-2:#be5046;--hue-6:#d19a66;--hue-6-2:#e6c07b}
+}
+.hljs{display:block;overflow-x:auto;padding:.5em;color:#383a42;color:var(--mono-1,#383a42);background:#fafafa;background:var(--base,#fafafa)}
+.hljs-comment,.hljs-quote{color:#717277;color:var(--mono-3,#717277);font-style:italic}
+.hljs-doctag,.hljs-formula,.hljs-keyword{color:#a626a4;color:var(--hue-3,#a626a4)}
+.hljs-deletion,.hljs-name,.hljs-section,.hljs-selector-tag,.hljs-subst{color:#ca4706;color:var(--hue-5,#ca4706);font-weight:700}
+.hljs-literal{color:#0b76c5;color:var(--hue-1,#0b76c5)}
+.hljs-addition,.hljs-attribute,.hljs-meta-string,.hljs-regexp,.hljs-string{color:#42803c;color:var(--hue-4,#42803c)}
+.hljs-built_in,.hljs-class .hljs-title{color:#9a6a01;color:var(--hue-6-2,#9a6a01)}
+.hljs-attr,.hljs-number,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-pseudo,.hljs-template-variable,.hljs-type,.hljs-variable{color:#986801;color:var(--hue-6,#986801)}
+.hljs-bullet,.hljs-link,.hljs-meta,.hljs-selector-id,.hljs-symbol,.hljs-title{color:#336ae3;color:var(--hue-2,#336ae3)}
+.hljs-emphasis{font-style:italic}
+.hljs-strong{font-weight:700}
+.hljs-link{text-decoration:underline}
+</style>
+<style>
+var{position:relative;cursor:pointer}
+var[data-type]::after,var[data-type]::before{position:absolute;left:50%;top:-6px;opacity:0;transition:opacity .4s;pointer-events:none}
+var[data-type]::before{content:"";transform:translateX(-50%);border-width:4px 6px 0 6px;border-style:solid;border-color:transparent;border-top-color:#222}
+var[data-type]::after{content:attr(data-type);transform:translateX(-50%) translateY(-100%);background:#222;text-align:center;font-family:"Dank Mono","Fira Code",monospace;font-style:normal;padding:6px;border-radius:3px;color:#daca88;text-indent:0;font-weight:400}
+var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
+</style>
+<script id="initialUserConfig" type="application/json">{
+  "wgPublicList": "public-vc-wg",
+  "group": "vc",
+  "specStatus": "NOTE",
+  "shortName": "vc-extensions",
+  "edDraftURI": "https://w3c.github.io/vc-extensions/",
+  "subtitle": "A list of extensions for Verifiable Credentials",
+  "publishDate": "2024-10-10",
+  "previousDiffURI": "https://www.w3.org/TR/2024/NOTE-vc-specs-dir-20240915/",
+  "github": {
+    "repoURL": "https://github.com/w3c/vc-extensions/",
+    "branch": "main"
+  },
+  "includePermalinks": false,
+  "editors": [
+    {
+      "name": "Manu Sporny",
+      "url": "https://www.linkedin.com/in/manusporny/",
+      "company": "Digital Bazaar",
+      "companyURL": "https://www.digitalbazaar.com/",
+      "w3cid": 41758
+    }
+  ],
+  "authors": [
+    {
+      "name": "Manu Sporny",
+      "url": "https://www.linkedin.com/in/manusporny/",
+      "company": "Digital Bazaar",
+      "companyURL": "https://www.digitalbazaar.com/",
+      "w3cid": 41758
+    }
+  ],
+  "otherLinks": [
+    {
+      "key": "Related Documents",
+      "data": [
+        {
+          "value": "Verifiable Credentials Data Model",
+          "href": "https://www.w3.org/TR/vc-data-model-2.0/"
+        }
+      ]
+    }
+  ],
+  "postProcess": [
+    null
+  ],
+  "publishISODate": "2024-10-10T00:00:00.000Z",
+  "generatedSubtitle": "W3C Group Note 10 October 2024"
+}</script>
+<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-NOTE"></head>
+<body class="h-entry"><div class="head">
+    <p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
+  </a></p>
+    <h1 id="title" class="title">Verifiable Credential Extensions</h1> <h2 id="subtitle" class="subtitle">A list of extensions for Verifiable Credentials</h2>
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#NOTE">W3C Group Note</a> <time class="dt-published" datetime="2024-10-10">10 October 2024</time></p>
+    <details open="">
+      <summary>More details about this document</summary>
+      <dl>
+        <dt>This version:</dt><dd>
+                <a class="u-url" href="https://www.w3.org/TR/2024/NOTE-vc-extensions-20241010/">https://www.w3.org/TR/2024/NOTE-vc-extensions-20241010/</a>
+              </dd>
+        <dt>Latest published version:</dt><dd>
+                <a href="https://www.w3.org/TR/vc-extensions/">https://www.w3.org/TR/vc-extensions/</a>
+              </dd>
+        <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/vc-extensions/">https://w3c.github.io/vc-extensions/</a></dd>
+        <dt>History:</dt><dd>
+                    <a href="https://www.w3.org/standards/history/vc-extensions/" data-previous-shortname="vc-specs-dir">https://www.w3.org/standards/history/vc-extensions/</a>
+                  </dd><dd>
+                    <a href="https://github.com/w3c/vc-extensions/commits/main">Commit history</a>
+                  </dd>
+        
+        
+        
+        
+        
+        <dt>Editor:</dt><dd class="editor p-author h-card vcard" data-editor-id="41758">
+    <a class="u-url url p-name fn" href="https://www.linkedin.com/in/manusporny/">Manu Sporny</a> (<a class="p-org org h-org" href="https://www.digitalbazaar.com/">Digital Bazaar</a>)
+  </dd>
+        
+        <dt>Author:</dt><dd class="editor p-author h-card vcard" data-editor-id="41758">
+    <a class="u-url url p-name fn" href="https://www.linkedin.com/in/manusporny/">Manu Sporny</a> (<a class="p-org org h-org" href="https://www.digitalbazaar.com/">Digital Bazaar</a>)
+  </dd>
+        <dt>Feedback:</dt><dd>
+        <a href="https://github.com/w3c/vc-extensions/">GitHub w3c/vc-extensions</a>
+        (<a href="https://github.com/w3c/vc-extensions/pulls/">pull requests</a>,
+        <a href="https://github.com/w3c/vc-extensions/issues/new/choose">new issue</a>,
+        <a href="https://github.com/w3c/vc-extensions/issues/">open issues</a>)
+      </dd><dd><a href="mailto:public-vc-wg@w3.org?subject=%5Bvc-extensions%5D%20YOUR%20TOPIC%20HERE">public-vc-wg@w3.org</a> with subject line <kbd>[vc-extensions] <em>… message topic …</em></kbd> (<a rel="discussion" href="https://lists.w3.org/Archives/Public/public-vc-wg">archives</a>)</dd>
+        
+        <dt>Related Documents</dt><dd>
+    <a href="https://www.w3.org/TR/vc-data-model-2.0/">Verifiable Credentials Data Model</a>
+  </dd>
+      </dl>
+    </details>
+    
+    
+    <p class="copyright">
+    <a href="https://www.w3.org/policies/#copyright">Copyright</a>
+    ©
+    2024
+    
+    <a href="https://www.w3.org/">World Wide Web Consortium</a>.
+    <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+    <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>,
+    <a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a> and
+    <a rel="license" href="https://www.w3.org/copyright/software-license-2023/" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.
+  </p>
+    <hr title="Separator for header">
+  </div>
+  <section id="abstract" class="introductory"><h2>Abstract</h2>
+    <p>
+This document serves as an unofficial list of all known Verifiable Credential
+specifications whether they are released by a global standards setting
+organization, a community group, an open source project, or an individual.
+    </p>
+  </section>
+
+  <section id="sotd" class="introductory"><h2>Status of This Document</h2><p><em>This section describes the status of this
+      document at the time of its publication. A list of current <abbr title="World Wide Web Consortium">W3C</abbr>
+      publications and the latest revision of this technical report can be found
+      in the <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at
+      https://www.w3.org/TR/.</em></p>
+
+    <p>
+This document is not a formal registry nor is it intended to become a
+<a href="https://www.w3.org/2023/Process-20231103/#registries">
+Registry Track</a> document per the <abbr title="World Wide Web Consortium">W3C</abbr> Process.
+    </p>
+
+    <p>
+Comments regarding this document are welcome. Please file issues
+directly on
+<a href="https://github.com/w3c/vc-extensions/issues/">GitHub</a>,
+or send them
+to <a href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a> (
+<a href="mailto:public-vc-wg-request@w3.org?subject=subscribe">subscribe</a>,
+<a href="https://lists.w3.org/Archives/Public/public-vc-wg/">archives</a>).
+    </p>
+
+  <p>
+    This document was published by the <a href="https://www.w3.org/groups/wg/vc">Verifiable Credentials Working Group</a> as
+    a Group Note using the
+        <a href="https://www.w3.org/policies/process/20231103/#recs-and-notes">Note track</a>. 
+  </p><p>This Group Note is endorsed by
+        the <a href="https://www.w3.org/groups/wg/vc">Verifiable Credentials Working Group</a>, but is not endorsed by
+        <abbr title="World Wide Web Consortium">W3C</abbr> itself nor its
+        Members. </p><p>
+    This is a draft document and may be updated, replaced or obsoleted by other
+    documents at any time. It is inappropriate to cite this document as other
+    than work in progress.
+    
+  </p><p data-deliverer="98922">
+    
+        The
+        <a href="https://www.w3.org/policies/patent-policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent
+          Policy</a>
+        does not carry any licensing requirements or commitments on this
+        document.
+      
+    
+  </p><p>
+                      This document is governed by the
+                      <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20231103/">03 November 2023 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+                    </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#abstract">Abstract</a></li><li class="tocline"><a class="tocxref" href="#sotd">Status of This Document</a></li><li class="tocline"><a class="tocxref" href="#introduction"><bdi class="secno">1. </bdi>Introduction</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#adding-a-specification-entry"><bdi class="secno">1.1 </bdi>Adding a Specification Entry</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#specification-entry-format"><bdi class="secno">1.1.1 </bdi>Specification Entry Format</a></li></ol></li><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">1.2 </bdi>Conformance</a></li></ol></li><li class="tocline"><a class="tocxref" href="#property-based-extensions"><bdi class="secno">2. </bdi>Property-based Extensions</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#credential-status"><bdi class="secno">2.1 </bdi>Credential Status</a></li><li class="tocline"><a class="tocxref" href="#credential-schema"><bdi class="secno">2.2 </bdi>Credential Schema</a></li><li class="tocline"><a class="tocxref" href="#evidence"><bdi class="secno">2.3 </bdi>Evidence</a></li><li class="tocline"><a class="tocxref" href="#proof"><bdi class="secno">2.4 </bdi>Proof</a></li><li class="tocline"><a class="tocxref" href="#refresh-service"><bdi class="secno">2.5 </bdi>Refresh Service</a></li><li class="tocline"><a class="tocxref" href="#terms-of-use"><bdi class="secno">2.6 </bdi>Terms of Use</a></li></ol></li><li class="tocline"><a class="tocxref" href="#type-based-extensions"><bdi class="secno">3. </bdi>Type-based Extensions</a></li><li class="tocline"><a class="tocxref" href="#securing-mechanisms"><bdi class="secno">4. </bdi>Securing Mechanisms</a></li><li class="tocline"><a class="tocxref" href="#media-type-extensions"><bdi class="secno">5. </bdi>Media Type Extensions</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">A. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">A.1 </bdi>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">A.2 </bdi>Informative references</a></li></ol></li></ol></nav>
+
+
+  <section class="informative" id="introduction"><div class="header-wrapper"><h2 id="x1-introduction"><bdi class="secno">1. </bdi>Introduction</h2><a class="self-link" href="#introduction" aria-label="Permalink for Section 1."></a></div><p><em>This section is non-normative.</em></p>
+    
+
+    <p>
+This document serves as an unofficial directory for all known Verifiable
+Credential specifications whether they are released by a global standards
+setting organization, a community group, an open source project, or an
+individual.
+    </p>
+
+    <section id="adding-a-specification-entry"><div class="header-wrapper"><h3 id="x1-1-adding-a-specification-entry"><bdi class="secno">1.1 </bdi>Adding a Specification Entry</h3><a class="self-link" href="#adding-a-specification-entry" aria-label="Permalink for Section 1.1"></a></div>
+      
+      <p>
+  The Verifiable Credentials Data Model is designed to be extended by 3rd party
+  specifications to address a variety of real world use cases. Examples of
+  extensions include, but are not limited to, new types of Verifiable Credentials
+  and ways of expressing credential status, schema validation, evidence,
+  refreshing, terms of use, and cryptographic suites for securing credentials.
+     </p>
+     <p> In
+  order to add a new specification to this directory, an implementer submits a
+  modification request for this directory, as a pull request on the repository
+  where this directory is hosted.
+  </p>
+
+  Here is an example:
+
+  <p>
+  </p><div class="example" id="example-1">
+        <div class="marker">
+    <a class="self-link" href="#example-1">Example<bdi> 1</bdi></a>
+  </div> <pre aria-busy="false"><code class="hljs json">{
+  <span class="hljs-attr">"name"</span>: <span class="hljs-string">"Example VC"</span>,
+  <span class="hljs-attr">"summary"</span>: <span class="hljs-string">"Used to demonstrate examples for Verifiable Credentials."</span>,
+  <span class="hljs-attr">"specification"</span>: <span class="hljs-string">"https://example.github.io/example-spec/"</span>,
+  <span class="hljs-attr">"category"</span>: <span class="hljs-string">"vc"</span>,
+  <span class="hljs-attr">"maintainerEmail"</span>: <span class="hljs-string">"maintainer@community.example"</span>,
+  <span class="hljs-attr">"maintainerName"</span>: <span class="hljs-string">"Example Community Group"</span>,
+  <span class="hljs-attr">"maintainerWebsite"</span>: <span class="hljs-string">"https://example.github.io/"</span>,
+  <span class="hljs-attr">"vocabulary"</span>: [<span class="hljs-string">"https://example.github.io/vocabularies/example.yml"</span>]
+}</code></pre>
+      </div>
+  <p></p>
+  <p>
+  The modification request <em class="rfc2119">MUST</em> adhere to the following policies:
+  </p>
+      <ol>
+        <li>
+Any addition to the directory <em class="rfc2119">MUST</em> conform to Section
+<a href="#specification-entry-format" class="sec-ref"><bdi class="secno">1.1.1 </bdi>Specification Entry Format</a>.
+        </li>
+        <li>
+If there are copyright, trademark, or any intellectual property rights
+concerns, the addition and use <em class="rfc2119">MUST</em> be authorized in writing by the intellectual
+property rights holder under a
+<a href="https://en.wikipedia.org/wiki/Reasonable_and_non-discriminatory_licensing">F/RAND</a>
+license. Examples include specifications that use trademarked brand names,
+property names that utilize the titles of copyrighted works, and patented
+technology that would cause the use of the extension to require licensing a
+patent.
+        </li>
+        <li>
+Any addition <em class="rfc2119">MUST NOT</em> create unreasonable legal, security, moral, or privacy
+issues that will result in direct harm to others. Examples of unacceptable
+additions include any containing racist language, technologies used to
+persecute minority populations, and unconsented pervasive tracking.
+        </li>
+      </ol>
+
+      <p>
+The Editors of this directory <em class="rfc2119">MUST</em> consider all of the policies above when
+reviewing additions to the directory and <em class="rfc2119">MUST</em> reject directory entries if they
+violate any of the policies in this section. Entities registering additions can
+challenge rejections first with the <abbr title="World Wide Web Consortium">W3C</abbr> Verifiable Credentials Working Group and
+then, if they are not satisfied with the outcome, with the <abbr title="World Wide Web Consortium">W3C</abbr> Staff. <abbr title="World Wide Web Consortium">W3C</abbr> Staff
+need not be consulted on changes to the directory, but do have the final
+authority on directory contents. This is to ensure that <abbr title="World Wide Web Consortium">W3C</abbr> can adequately
+respond to time sensitive legal, privacy, security, moral, or other pressing
+concerns without putting an undue operational burden on <abbr title="World Wide Web Consortium">W3C</abbr> Staff.
+      </p>
+
+      <p>
+Any submission to the directory that meets all of the criteria listed above will
+be accepted for inclusion. The specifications listed in this directory enumerate
+all known specifications, without choosing between them.
+      </p>
+
+      <section id="specification-entry-format"><div class="header-wrapper"><h4 id="x1-1-1-specification-entry-format"><bdi class="secno">1.1.1 </bdi>Specification Entry Format</h4><a class="self-link" href="#specification-entry-format" aria-label="Permalink for Section 1.1.1"></a></div>
+        
+        <p>
+The specification entry format <em class="rfc2119">MUST</em> conform to the
+<a href="https://w3c.github.io/vc-extensions/tooling/specification-entry.yml">
+JSON Schema for a specification entry</a>. Each field is documented below:
+        </p>
+        <table class="simple">
+          <thead>
+            <tr><th>Field</th>
+            <th>Description</th>
+          </tr></thead>
+          <tbody>
+            <tr>
+              <td>name</td>
+              <td>
+A short human readable name for the specification. For example: <code>Status List
+(v2021)</code>.
+              </td>
+            </tr>
+            <tr>
+              <td>summary</td>
+              <td>
+A one sentence description for the specification. For example: <code>A credential
+status list with herd privacy characteristics.</code>
+              </td>
+            </tr>
+            <tr>
+              <td>specification</td>
+              <td>
+An URL that resolves to a human readable specification. For example:
+<code>https://w3c.github.io/vc-status-list-2021/</code>.
+              </td>
+            </tr>
+            <tr>
+              <td>category</td>
+              <td>
+The Verifiable Credential extension category of the specification, which can
+be one of the following values: <code>credentialStatus</code>, <code>credentialSchema</code>,
+<code>evidence</code>, <code>media-type</code>, <code>securing</code>, <code>refreshService</code>, <code>termsOfUse</code>, or <code>vc</code>.
+For example: <code>credentialStatus</code>.
+              <div class="note" role="note" id="issue-container-generatedID"><div role="heading" class="note-title marker" id="h-note" aria-level="5"><span>Note</span></div><p class="">
+The extensions might define a <code>@type</code>. See [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">JSON-LD11</a></cite>].
+              </p></div>
+              </td>
+            </tr>
+            <tr>
+              <td>maintainerName</td>
+              <td>
+A person or organization which responds to contact requests. For example:
+<code>W3C Verifiable Credentials Working Group</code>.
+              </td>
+            </tr>
+            <tr>
+              <td>maintainerEmail</td>
+              <td>
+An email to send contact requests. For example:
+<code>public-vc-wg@w3.org</code>.
+              </td>
+            </tr>
+            <tr>
+              <td>maintainerWebsite</td>
+              <td>
+An website to send contact requests. For example:
+<code>https://www.w3.org/groups/wg/vc</code>.
+              </td>
+            </tr>
+            <tr>
+              <td>vocabulary</td>
+              <td>
+An array of URLs that contain machine-readable vocabulary information in
+yml2vocab or JSON-LD format. For example:
+<code>["https://raw.githubusercontent.com/w3c/vc-status-list-2021/main/contexts/v1.jsonld"]</code>.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+
+    <section id="conformance"><div class="header-wrapper"><h3 id="x1-2-conformance"><bdi class="secno">1.2 </bdi>Conformance</h3><a class="self-link" href="#conformance" aria-label="Permalink for Section 1.2"></a></div><p>As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.</p><p>
+        The key words <em class="rfc2119">MUST</em> and <em class="rfc2119">MUST NOT</em> in this document
+        are to be interpreted as described in
+        <a href="https://datatracker.ietf.org/doc/html/bcp14">BCP 14</a>
+        [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">RFC2119</a></cite>] [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8174" title="Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words">RFC8174</a></cite>]
+        when, and only when, they appear in all capitals, as shown here.
+      </p></section>
+
+  </section>
+
+
+
+  <section id="property-based-extensions"><div class="header-wrapper"><h2 id="x2-property-based-extensions"><bdi class="secno">2. </bdi>Property-based Extensions</h2><a class="self-link" href="#property-based-extensions" aria-label="Permalink for Section 2."></a></div>
+    
+
+    <section id="credential-status"><div class="header-wrapper"><h3 id="x2-1-credential-status"><bdi class="secno">2.1 </bdi>Credential Status</h3><a class="self-link" href="#credential-status" aria-label="Permalink for Section 2.1"></a></div>
+      
+
+      <table class="simple">
+        <thead>
+          <tr><th>Specification</th><th>Description</th>
+        </tr></thead>
+        <tbody id="credentialStatus-table">
+
+        </tbody>
+      </table>
+
+    </section>
+    <section id="credential-schema"><div class="header-wrapper"><h3 id="x2-2-credential-schema"><bdi class="secno">2.2 </bdi>Credential Schema</h3><a class="self-link" href="#credential-schema" aria-label="Permalink for Section 2.2"></a></div>
+      
+
+      <table class="simple">
+        <thead>
+          <tr><th>Specification</th><th>Description</th>
+        </tr></thead>
+        <tbody id="credentialSchema-table">
+
+        </tbody>
+      </table>
+
+    </section>
+    <section id="evidence"><div class="header-wrapper"><h3 id="x2-3-evidence"><bdi class="secno">2.3 </bdi>Evidence</h3><a class="self-link" href="#evidence" aria-label="Permalink for Section 2.3"></a></div>
+      
+
+      <table class="simple">
+        <thead>
+          <tr><th>Specification</th><th>Description</th>
+        </tr></thead>
+        <tbody id="evidence-table">
+
+        </tbody>
+      </table>
+
+    </section>
+    <section id="proof"><div class="header-wrapper"><h3 id="x2-4-proof"><bdi class="secno">2.4 </bdi>Proof</h3><a class="self-link" href="#proof" aria-label="Permalink for Section 2.4"></a></div>
+      
+
+      See Section <a href="#securing-mechanisms" class="sec-ref"><bdi class="secno">4. </bdi>Securing Mechanisms</a>.
+
+    </section>
+    <section id="refresh-service"><div class="header-wrapper"><h3 id="x2-5-refresh-service"><bdi class="secno">2.5 </bdi>Refresh Service</h3><a class="self-link" href="#refresh-service" aria-label="Permalink for Section 2.5"></a></div>
+      
+
+      <table class="simple">
+        <thead>
+          <tr><th>Specification</th><th>Description</th>
+        </tr></thead>
+        <tbody id="refreshService-table">
+
+        </tbody>
+      </table>
+
+    </section>
+    <section id="terms-of-use"><div class="header-wrapper"><h3 id="x2-6-terms-of-use"><bdi class="secno">2.6 </bdi>Terms of Use</h3><a class="self-link" href="#terms-of-use" aria-label="Permalink for Section 2.6"></a></div>
+      
+
+      <table class="simple">
+        <thead>
+          <tr><th>Specification</th><th>Description</th>
+        </tr></thead>
+        <tbody id="termsOfUse-table">
+
+        </tbody>
+      </table>
+
+    </section>
+  </section>
+  <section id="type-based-extensions"><div class="header-wrapper"><h2 id="x3-type-based-extensions"><bdi class="secno">3. </bdi>Type-based Extensions</h2><a class="self-link" href="#type-based-extensions" aria-label="Permalink for Section 3."></a></div>
+    
+
+    <table class="simple">
+      <thead>
+        <tr><th>Specification</th><th>Description</th>
+      </tr></thead>
+      <tbody id="vc-table">
+
+      </tbody>
+    </table>
+
+  </section>
+
+  <section id="securing-mechanisms"><div class="header-wrapper"><h2 id="x4-securing-mechanisms"><bdi class="secno">4. </bdi>Securing Mechanisms</h2><a class="self-link" href="#securing-mechanisms" aria-label="Permalink for Section 4."></a></div>
+    
+
+    <table class="simple">
+      <thead>
+        <tr><th>Specification</th><th>Description</th>
+      </tr></thead>
+      <tbody id="securing-table">
+
+      </tbody>
+    </table>
+
+  </section>
+
+  <section id="media-type-extensions"><div class="header-wrapper"><h2 id="x5-media-type-extensions"><bdi class="secno">5. </bdi>Media Type Extensions</h2><a class="self-link" href="#media-type-extensions" aria-label="Permalink for Section 5."></a></div>
+    
+
+    <table class="simple">
+      <thead>
+        <tr><th>Specification</th><th>Description</th>
+      </tr></thead>
+      <tbody id="media-type-table">
+
+      </tbody>
+    </table>
+
+  </section>
+
+
+
+<section id="references" class="appendix"><div class="header-wrapper"><h2 id="a-references"><bdi class="secno">A. </bdi>References</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix A."></a></div><section id="normative-references"><div class="header-wrapper"><h3 id="a-1-normative-references"><bdi class="secno">A.1 </bdi>Normative references</h3><a class="self-link" href="#normative-references" aria-label="Permalink for Appendix A.1"></a></div>
+    
+    <dl class="bibliography"><dt id="bib-rfc2119">[RFC2119]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
+    </dd><dt id="bib-rfc8174">[RFC8174]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc8174"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc8174">https://www.rfc-editor.org/rfc/rfc8174</a>
+    </dd></dl>
+  </section><section id="informative-references"><div class="header-wrapper"><h3 id="a-2-informative-references"><bdi class="secno">A.2 </bdi>Informative references</h3><a class="self-link" href="#informative-references" aria-label="Permalink for Appendix A.2"></a></div>
+    
+    <dl class="bibliography"><dt id="bib-json-ld11">[JSON-LD11]</dt><dd>
+      <a href="https://www.w3.org/TR/json-ld11/"><cite>JSON-LD 1.1</cite></a>. Gregg Kellogg; Pierre-Antoine Champin; Dave Longley.  W3C. 16 July 2020. W3C Recommendation. URL: <a href="https://www.w3.org/TR/json-ld11/">https://www.w3.org/TR/json-ld11/</a>
+    </dd></dl>
+  </section></section><p role="navigation" id="back-to-top">
+    <a href="#title"><abbr title="Back to Top">↑</abbr></a>
+  </p><script id="respec-dfn-panel">(() => {
+// @ts-check
+if (document.respec) {
+  document.respec.ready.then(setupPanel);
+} else {
+  setupPanel();
+}
+
+function setupPanel() {
+  const listener = panelListener();
+  document.body.addEventListener("keydown", listener);
+  document.body.addEventListener("click", listener);
+}
+
+function panelListener() {
+  /** @type {HTMLElement} */
+  let panel = null;
+  return event => {
+    const { target, type } = event;
+
+    if (!(target instanceof HTMLElement)) return;
+
+    // For keys, we only care about Enter key to activate the panel
+    // otherwise it's activated via a click.
+    if (type === "keydown" && event.key !== "Enter") return;
+
+    const action = deriveAction(event);
+
+    switch (action) {
+      case "show": {
+        hidePanel(panel);
+        /** @type {HTMLElement} */
+        const dfn = target.closest("dfn, .index-term");
+        panel = document.getElementById(`dfn-panel-for-${dfn.id}`);
+        const coords = deriveCoordinates(event);
+        displayPanel(dfn, panel, coords);
+        break;
+      }
+      case "dock": {
+        panel.style.left = null;
+        panel.style.top = null;
+        panel.classList.add("docked");
+        break;
+      }
+      case "hide": {
+        hidePanel(panel);
+        panel = null;
+        break;
+      }
+    }
+  };
+}
+
+/**
+ * @param {MouseEvent|KeyboardEvent} event
+ */
+function deriveCoordinates(event) {
+  const target = /** @type HTMLElement */ (event.target);
+
+  // We prevent synthetic AT clicks from putting
+  // the dialog in a weird place. The AT events sometimes
+  // lack coordinates, so they have clientX/Y = 0
+  const rect = target.getBoundingClientRect();
+  if (
+    event instanceof MouseEvent &&
+    event.clientX >= rect.left &&
+    event.clientY >= rect.top
+  ) {
+    // The event probably happened inside the bounding rect...
+    return { x: event.clientX, y: event.clientY };
+  }
+
+  // Offset to the middle of the element
+  const x = rect.x + rect.width / 2;
+  // Placed at the bottom of the element
+  const y = rect.y + rect.height;
+  return { x, y };
+}
+
+/**
+ * @param {Event} event
+ */
+function deriveAction(event) {
+  const target = /** @type {HTMLElement} */ (event.target);
+  const hitALink = !!target.closest("a");
+  if (target.closest("dfn:not([data-cite]), .index-term")) {
+    return hitALink ? "none" : "show";
+  }
+  if (target.closest(".dfn-panel")) {
+    if (hitALink) {
+      return target.classList.contains("self-link") ? "hide" : "dock";
+    }
+    const panel = target.closest(".dfn-panel");
+    return panel.classList.contains("docked") ? "hide" : "none";
+  }
+  if (document.querySelector(".dfn-panel:not([hidden])")) {
+    return "hide";
+  }
+  return "none";
+}
+
+/**
+ * @param {HTMLElement} dfn
+ * @param {HTMLElement} panel
+ * @param {{ x: number, y: number }} clickPosition
+ */
+function displayPanel(dfn, panel, { x, y }) {
+  panel.hidden = false;
+  // distance (px) between edge of panel and the pointing triangle (caret)
+  const MARGIN = 20;
+
+  const dfnRects = dfn.getClientRects();
+  // Find the `top` offset when the `dfn` can be spread across multiple lines
+  let closestTop = 0;
+  let minDiff = Infinity;
+  for (const rect of dfnRects) {
+    const { top, bottom } = rect;
+    const diffFromClickY = Math.abs((top + bottom) / 2 - y);
+    if (diffFromClickY < minDiff) {
+      minDiff = diffFromClickY;
+      closestTop = top;
+    }
+  }
+
+  const top = window.scrollY + closestTop + dfnRects[0].height;
+  const left = x - MARGIN;
+  panel.style.left = `${left}px`;
+  panel.style.top = `${top}px`;
+
+  // Find if the panel is flowing out of the window
+  const panelRect = panel.getBoundingClientRect();
+  const SCREEN_WIDTH = Math.min(window.innerWidth, window.screen.width);
+  if (panelRect.right > SCREEN_WIDTH) {
+    const newLeft = Math.max(MARGIN, x + MARGIN - panelRect.width);
+    const newCaretOffset = left - newLeft;
+    panel.style.left = `${newLeft}px`;
+    /** @type {HTMLElement} */
+    const caret = panel.querySelector(".caret");
+    caret.style.left = `${newCaretOffset}px`;
+  }
+
+  // As it's a dialog, we trap focus.
+  // TODO: when <dialog> becomes a implemented, we should really
+  // use that.
+  trapFocus(panel, dfn);
+}
+
+/**
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function trapFocus(panel, dfn) {
+  /** @type NodeListOf<HTMLAnchorElement> elements */
+  const anchors = panel.querySelectorAll("a[href]");
+  // No need to trap focus
+  if (!anchors.length) return;
+
+  // Move focus to first anchor element
+  const first = anchors.item(0);
+  first.focus();
+
+  const trapListener = createTrapListener(anchors, panel, dfn);
+  panel.addEventListener("keydown", trapListener);
+
+  // Hiding the panel releases the trap
+  const mo = new MutationObserver(records => {
+    const [record] = records;
+    const target = /** @type HTMLElement */ (record.target);
+    if (target.hidden) {
+      panel.removeEventListener("keydown", trapListener);
+      mo.disconnect();
+    }
+  });
+  mo.observe(panel, { attributes: true, attributeFilter: ["hidden"] });
+}
+
+/**
+ *
+ * @param {NodeListOf<HTMLAnchorElement>} anchors
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function createTrapListener(anchors, panel, dfn) {
+  const lastIndex = anchors.length - 1;
+  let currentIndex = 0;
+  return event => {
+    switch (event.key) {
+      // Hitting "Tab" traps us in a nice loop around elements.
+      case "Tab": {
+        event.preventDefault();
+        currentIndex += event.shiftKey ? -1 : +1;
+        if (currentIndex < 0) {
+          currentIndex = lastIndex;
+        } else if (currentIndex > lastIndex) {
+          currentIndex = 0;
+        }
+        anchors.item(currentIndex).focus();
+        break;
+      }
+
+      // Hitting "Enter" on an anchor releases the trap.
+      case "Enter":
+        hidePanel(panel);
+        break;
+
+      // Hitting "Escape" returns focus to dfn.
+      case "Escape":
+        hidePanel(panel);
+        dfn.focus();
+        return;
+    }
+  };
+}
+
+/** @param {HTMLElement} panel */
+function hidePanel(panel) {
+  if (!panel) return;
+  panel.hidden = true;
+  panel.classList.remove("docked");
+}
+})()</script><script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script></body></html>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,9 @@ var respecConfig = {
   subtitle: "A list of extensions for Verifiable Credentials",
 
   // if you wish the publication date to be other than today, set this
-  publishDate:  "2024-09-17",
+  publishDate:  "2024-10-10",
+
+  // previousDiffURI: "https://www.w3.org/TR/2024/NOTE-vc-specs-dir-20240915/",
 
   // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
   // and its maturity status


### PR DESCRIPTION
I have made a new version for the publication on October 10. (This is, in my view, the first possible publication date.)

Notes:

- I have not run this version against pubrules (ran out of time right now). @msporny, can you do that?
- I have added the `previousDiffURI: "https://www.w3.org/TR/2024/NOTE-vc-specs-dir-20240915/"` to the respec header, but respec still does not seem to have added the relevant `data-` attribute to the history reference. TBD if the new version of the note is generated.
- Respec raises an error, which I decided to ignore for now

<img width="942" alt="Screenshot 2024-09-16 at 08 36 13" src="https://github.com/user-attachments/assets/12430aeb-9ee6-444c-8297-5f781b2d1dcd">

- The echidna script must be disabled until after the publication and before merging this branch!


For the record: the official publication has been requested: https://github.com/w3c/transitions/issues/654


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-extensions/pull/39.html" title="Last updated on Sep 16, 2024, 6:43 AM UTC (372b48e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-extensions/39/593bda3...372b48e.html" title="Last updated on Sep 16, 2024, 6:43 AM UTC (372b48e)">Diff</a>